### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ aws configure # needed for your AWS access
 export AWS_REGION=$your_region # speeds up puppet aws module tremendously
 export FACTER_aws_region=$your_region # needed for hiera
 export FACTER_user=$your_user_name # needed for hiera
-sudo /opt/puppetlabs/puppet/bin/gem install aws-sdk retries --no-ri --no-rdoc
+sudo /opt/puppetlabs/puppet/bin/gem install aws-sdk:2.11.71 retries --no-ri --no-rdoc
 puppet module install puppetlabs/aws
 puppet module install puppetlabs/stdlib
 ```


### PR DESCRIPTION
Suggesting this change because when I first ran 'provision.sh master' it failed with a message "uninitialized constant Aws::EC2" which apparently was caused by the following version incompatibility issue:
https://github.com/puppetlabs/puppetlabs-aws/issues/476

I deleted version 3 of aws-sdk and reinstalled (downgraded) to version 2 and the problem went away.