### PR TITLE
create_dockerhost.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ awskit::host_config:
 
 - run `tasks/provision.sh gitlab`
 
+### Provision the Docker host
+
+- run `tasks/provision.sh dockerhost`
+
 ### Configure the control repo
 
 Out of the box, the Puppetmasters come with a running Gitea git server with a demo control repo configured: https://github.com/puppetlabs-seteam/control-repo. You can clone this control repo to your local machine, customize it and push to Gitea. Alternatively, you can push a totally different control repo to Gitea.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,7 @@ the role `cd4pe_server` which is available in the control repo.
 * [`awskit::create_linux_node`](#awskitcreate_linux_node): Creates $count Linux nodes
 * [`awskit::create_linux_role`](#awskitcreate_linux_role): Creates $count Linux nodes with a role
 * [`awskit::create_master`](#awskitcreate_master): Provision a Puppetmaster in AWS
+* [`awskit::create_dockerhost`](#awskitcreate_dockerhost): Provision a base demo docker host on which containerized stacks can be auto-configured via custom user_data. Includes docker-compose
 * [`awskit::create_windc`](#awskitcreate_windc): Installs AWS instance for Windows Domain Controller installation
 * [`awskit::create_windows_node`](#awskitcreate_windows_node): Creates a number of Windows nodes
 * [`awskit::create_wsus`](#awskitcreate_wsus): A short summary of the purpose of this class

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,6 +15,7 @@ awskit::create_artifactory::instance_type: "t2.small"
 awskit::create_bolt_workshop_master::instance_type: "t3.large"
 awskit::create_bolt_workshop_targets::instance_type_linux: "t3.micro"
 awskit::create_bolt_workshop_targets::instance_type_windows: "t3.small"
+awskit::create_dockerhost::instance_type: "t2.large"
 
 awskit::windows_domain::dn: "DC=awskit,DC=local"
 awskit::windows_domain::localadminpw: "PuppetD3vh0ps!"
@@ -37,6 +38,7 @@ awskit::create_gitlab::instance_name: "%{facts.user}-awskit-gitlab"
 awskit::create_artifactory::instance_name: "%{facts.user}-awskit-artifactory"
 awskit::create_bolt_workshop_master::instance_name: "%{facts.user}-awskit-boltws-master"
 awskit::create_bolt_workshop_targets::instance_name: "%{facts.user}-awskit-boltws"
+awskit::create_dockerhost::instance_name: "%{facts.user}-awskit-dockerhost"
 
 awskit::tags:
   description: "SE Demo Infrastructure"
@@ -93,6 +95,15 @@ awskit::create_windows_node::user_data: |
 
 awskit::create_linux_node::count: 2
 awskit::create_windows_node::count: 2
+
+awskit::create_dockerhost::user_data: |
+  #! /bin/bash
+  yum install -y yum-utils device-mapper-persistent-data lvm2 git
+  yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  yum install -y docker-ce
+  systemctl enable docker
+  systemctl start docker
+  curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` -o /bin/docker-compose && chmod +x /bin/docker-compose
 
 awskit::create_discovery::user_data: |
   #! /bin/bash

--- a/data/eric.boutilier.yaml
+++ b/data/eric.boutilier.yaml
@@ -1,0 +1,29 @@
+lookup_options:
+  awskit::tags:
+    merge: deep
+
+awskit::tags:
+  created_by: "eric.boutilier@puppet.com"
+
+# awskit::create_dockerhost::instance_type: "t2.xlarge"
+
+awskit::create_dockerhost::user_data: |
+  #! /bin/bash
+  # This block is just a copy of the user_data in common.yaml. It sets up a base dockerhost
+  yum install -y yum-utils device-mapper-persistent-data lvm2 git
+  yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  yum install -y docker-ce
+  systemctl enable docker
+  systemctl start docker
+  curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` -o /bin/docker-compose && chmod +x /bin/docker-compose
+  #
+  # This block is for running docker app(s) on this instance.
+  ### Splunk Enterprise:
+  # docker pull splunk/splunk:latest
+  # docker run -d -p 8000:8000 -e 'SPLUNK_START_ARGS=--accept-license' -e 'SPLUNK_PASSWORD=admin' splunk/splunk:latest
+
+  ### Pupperware:
+  cd /root
+  git clone https://github.com/puppetlabs/pupperware.git && \
+  cd pupperware && \
+  docker-compose up -d

--- a/data/us-west-2/eric.boutilier.yaml
+++ b/data/us-west-2/eric.boutilier.yaml
@@ -1,0 +1,6 @@
+---
+awskit::key_name: 'ericb-west'
+awskit::vpc: 'default-vpc'
+awskit::subnet: 'default'
+awskit::availability_zone: 'us-west-2a'
+awskit::master_ip: '54.244.17.142'

--- a/manifests/create_dockerhost.pp
+++ b/manifests/create_dockerhost.pp
@@ -15,7 +15,7 @@ class awskit::create_dockerhost (
 
   include awskit
 
-  $ami = $awskit::centos_ami,
+  $ami = $awskit::centos_ami
 
   ec2_securitygroup { "${facts['user']}-awskit-dockerhost":
     ensure      => 'present',

--- a/manifests/create_dockerhost.pp
+++ b/manifests/create_dockerhost.pp
@@ -1,0 +1,42 @@
+# awskit::create_dockerhost
+#
+# This class creates an instance in AWS for Puppet Discovery to be installed on
+#
+# @summary Installs AWS instance for Puppet Discovery installation
+#
+# @example
+#   include awskit::create_dockerhost
+class awskit::create_dockerhost (
+  $instance_type,
+  $user_data,
+  $count         = 1,
+  $instance_name = 'awskit-dockerhost',
+) {
+
+  include awskit
+
+  $ami = $awskit::centos_ami,
+
+  ec2_securitygroup { "${facts['user']}-awskit-dockerhost":
+    ensure      => 'present',
+    region      => $awskit::region,
+    vpc         => $awskit::vpc,
+    description => 'ingress for awskit dockerhost',
+    ingress     => [
+      { protocol => 'tcp', port => 22,   cidr => '0.0.0.0/0', },   # ssh
+      { protocol => 'tcp', port => 80,   cidr => '0.0.0.0/0', },   # http
+      { protocol => 'tcp', port => 443,  cidr => '0.0.0.0/0', },   # https
+      { protocol => 'tcp', port => 8000,   cidr => '0.0.0.0/0', }, # splunk
+      { protocol => 'tcp', port => 8080,   cidr => '0.0.0.0/0', }, # discovery
+      { protocol => 'tcp', port => 8443,   cidr => '0.0.0.0/0', }, # discovery
+      { protocol => 'icmp',              cidr => '0.0.0.0/0', },
+    ],
+  }
+
+  awskit::create_host { $instance_name:
+    ami             => $ami,
+    instance_type   => $instance_type,
+    user_data       => $user_data,
+    security_groups => ["${facts['user']}-awskit-dockerhost"],
+  }
+}

--- a/spec/classes/awskit_create_dockerhost_spec.rb
+++ b/spec/classes/awskit_create_dockerhost_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'awskit::create_dockerhost' do
+  let(:facts) { RSpec.configuration.default_facts }
+
+  let(:params) do
+    {
+      'instance_name' => 'my-instance-name',
+      'count'         => 1,
+    }
+  end
+
+  it { is_expected.to compile }
+  it { is_expected.to contain_awskit__create_host(params['instance_name'].to_s) }
+  it { is_expected.to contain_ec2_securitygroup("#{facts['user']}-awskit-dockerhost") }
+end

--- a/tasks/provision.sh
+++ b/tasks/provision.sh
@@ -15,7 +15,7 @@ Usage in task mode:
 
 [_noop="yes"] [PT_count=<count>] PT_type=<type> $0
 
-- type should be one of: ['master', 'linux_node', 'windows_node', 'discovery', 'windc', 'wsus', 'cd4pe','gitlab']
+- type should be one of: ['master', 'linux_node', 'windows_node', 'discovery', 'windc', 'wsus', 'cd4pe','gitlab', 'dockerhost']
 - count should be an integer, default: value configured in hiera
 
 Examples:
@@ -76,6 +76,7 @@ case $PT_type in
   wsus) PT_count=1 ;;
   cd4pe) PT_count=1 ;;
   gitlab) PT_count=1 ;;  
+  dockerhost) PT_count=1 ;;  
   *) 
     echo "unknown type $PT_type specified."
     usage 


### PR DESCRIPTION
New manifest create_dockerhost.pp and related changes.  It creates a base dockerhost, including docker-compose.

Also adding:
- data/eric.boutilier.yaml
- data/us-west-2/eric.boutilier.yaml

To actually run docker apps on the created docker host, I override the user_data block in common.yaml with a custom user_data block in my hiera file. Containerized Splunk Enterprise and pupperware are included as examples.

Question... Is it possible to append to a hiera value instead of override it? That would be ideal.
