### PR TITLE
Add a docker-enabled AMI

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -63,6 +63,7 @@ awskit::amis:
     discovery: ami-b63ae0ce # CentOS Linux 7 x86_64 HVM EBS 1708_11.01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-95096eef.4
     windc: ami-017bf00eb0d4c7182 # Windows_Server-2016-English-Full-Base-2018.10.14
     wsus: ami-017bf00eb0d4c7182 # Windows_Server-2016-English-Full-Base-2018.10.14
+    docker: ami-08a73ef2db6c656e5 # Docker optimized Amazon Linux AMI 2.0.20190127 x86_64 ECS HVM GP2 - https://tinyurl.com/y9f6ao4t
   us-east-1: # N. Virginia
     pm: ami-04093f611cb0dd860 # tse-master-virtualbox-2019.0.0-v0.1.1.vmdk
     centos: ami-02e98f78 # CentOS Linux 7 x86_64 HVM EBS 1708_11.01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-95096eef.4
@@ -70,6 +71,7 @@ awskit::amis:
     discovery: ami-02e98f78 # CentOS Linux 7 x86_64 HVM EBS 1708_11.01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-95096eef.4
     windc: ami-050202fb72f001b47 # Windows_Server-2016-English-Full-Base-2018.10.14
     wsus: ami-050202fb72f001b47 # Windows_Server-2016-English-Full-Base-2018.10.14
+    docker: ami-014810e050a2986e9 # Docker optimized Amazon Linux AMI 2.0.20190127 x86_64 ECS HVM GP2 - https://tinyurl.com/y9f6ao4t
   eu-west-2: # London
     pm: ami-01c346f78bfcbaf57 # tse-master-virtualbox-2019.0.0-v0.1.1.vmdk
     centos: ami-00846a67 # CentOS Linux 7 x86_64 HVM EBS ENA 1805_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-77ec9308.4
@@ -77,11 +79,13 @@ awskit::amis:
     discovery: ami-00846a67 # CentOS Linux 7 x86_64 HVM EBS ENA 1805_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-77ec9308.4
     windc: ami-0f5f78829606035fc # Windows_Server-2016-English-Full-Base-2018.10.14
     wsus: ami-0f5f78829606035fc # Windows_Server-2016-English-Full-Base-2018.10.14
+    docker: ami-0b48a90115318e01c # Docker optimized Amazon Linux AMI 2.0.20190127 x86_64 ECS HVM GP2 - https://tinyurl.com/y9f6ao4t
   eu-west-3: # Paris
     pm: ami-03c5efa0c2682cd6b # tse-master-virtualbox-2019.0.0-v0.1.1.vmdk
     centos: ami-262e9f5b # CentOS Linux 7 x86_64 HVM EBS ENA 1805_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-77ec9308.4
     discovery: ami-262e9f5b # CentOS Linux 7 x86_64 HVM EBS ENA 1805_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-77ec9308.4
     windows: ami-041c2ed9f395ea43f # Windows_Server-2016-English-Full-Base-2018.11.28
+    docker: ami-0d86fa8483cfc9a34 # Docker optimized Amazon Linux AMI 2.0.20190127 x86_64 ECS HVM GP2 - https://tinyurl.com/y9f6ao4t
   eu-central-1: # Frankfurt
     pm: ami-0aadcb439247edc90 # tse-master-virtualbox-2019.0.0-v0.1.1.vmdk
   ap-southeast-2: # Sydney

--- a/manifests/create_dockerhost.pp
+++ b/manifests/create_dockerhost.pp
@@ -14,7 +14,7 @@ class awskit::create_dockerhost (
 
   include awskit
 
-  $ami = $awskit::centos_ami
+  $ami = $awskit::docker_ami
 
   ec2_securitygroup { "${facts['user']}-awskit-dockerhost":
     ensure      => 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class awskit(
   ) {
 
     $pm_ami          = $amis[$region]['pm']
+    $docker_ami      = $amis[$region]['docker']
     $centos_ami      = $amis[$region]['centos']
     $windows_ami     = $amis[$region]['windows']
     $discovery_ami   = $amis[$region]['discovery']

--- a/templates/dockerhost_userdata.epp
+++ b/templates/dockerhost_userdata.epp
@@ -1,7 +1,18 @@
 #! /bin/bash
-yum install -y yum-utils device-mapper-persistent-data lvm2 git
-yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-yum install -y docker-ce
-systemctl enable docker
-systemctl start docker
-curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` -o /bin/docker-compose && chmod +x /bin/docker-compose
+## This script assumes the AMI already has docker built in such as an image from the Moby Project, an Amazon ECS image, etc.
+
+## Add docker-compose. Some source repos need it.
+compose_version=1.23.2
+curl -L https://github.com/docker/compose/releases/download/${compose_version}/docker-compose-`uname -s`-`uname -m` \
+  -o /bin/docker-compose && \
+  chmod +x /bin/docker-compose
+
+## Add git. Some installation methods need it
+yum install -y git
+
+### Sample apps
+### Pupperware
+cd /root
+git clone https://github.com/puppetlabs/pupperware.git && \
+cd pupperware && \
+docker-compose up -d

--- a/templates/dockerhost_userdata.epp
+++ b/templates/dockerhost_userdata.epp
@@ -1,18 +1,43 @@
 #! /bin/bash
-## This script assumes the AMI already has docker built in such as an image from the Moby Project, an Amazon ECS image, etc.
+#
+# Docker app examples. Uncomment or add as needed.
+#
+## Optionally uncomment the following line to add git, e.g. pupperware depends on it
+# yum install -y git
 
-## Add docker-compose. Some source repos need it.
-compose_version=1.23.2
-curl -L https://github.com/docker/compose/releases/download/${compose_version}/docker-compose-`uname -s`-`uname -m` \
-  -o /bin/docker-compose && \
-  chmod +x /bin/docker-compose
+## Optionally uncomment the following 4 lines to add docker-compose, e.g. pupperware depends on it
+# compose_version=1.23.2
+# curl -L https://github.com/docker/compose/releases/download/${compose_version}/docker-compose-`uname -s`-`uname -m` \
+#   -o /bin/docker-compose && \
+#   chmod +x /bin/docker-compose
 
-## Add git. Some installation methods need it
-yum install -y git
+### Sample apps...
 
-### Sample apps
-### Pupperware
-cd /root
-git clone https://github.com/puppetlabs/pupperware.git && \
-cd pupperware && \
-docker-compose up -d
+## Uncomment to install pupperware
+# cd /root
+# git clone https://github.com/puppetlabs/pupperware.git && \
+# cd pupperware && \
+# docker-compose up -d
+
+
+# Uncomment to install Splunk Enterprise
+#
+## Notes: The below Dockerfile pulls the base splunk image from dockerhub and configures 
+## it to accept the license and to set a password on startup. It also preps it w/ env 
+## vars for customizing, e.g. for puppet/splunk integration demo
+#
+# cd /root
+# cat > ./Dockerfile << "EOF"
+# FROM splunk/splunk:latest
+# RUN sudo apt-get update && sudo apt-get install -y git
+# ENV SPLUNK_START_ARGS --accept-license
+# ENV SPLUNK_PASSWORD puppetlabs
+# ENV GITHUB_URL https://github.com/puppetlabs
+# ENV APP1 SplunkTAforPuppetEnterprise
+# ENV APP2 SplunkAppforPuppetEnterprise
+# EOF
+
+# docker build -t splunkdemo_i .
+# docker run --name splunkdemo_c -d -p 8000:8000 splunkdemo_i
+# docker exec splunkdemo_c bash -c 'sudo git clone "${GITHUB_URL}/${APP1}.git" "/opt/splunk/etc/apps/${APP1}"'
+# docker exec splunkdemo_c bash -c 'sudo git clone "${GITHUB_URL}/${APP2}.git" "/opt/splunk/etc/apps/${APP2}"'


### PR DESCRIPTION
Add Amazon's docker-enabled AMI. Purpose is to simplify user data templates that deploy docker stacks/apps