### PR TITLE
Update Windows AMI in eu-west-3 to latest

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -86,7 +86,7 @@ awskit::amis:
     pm: ami-03c5efa0c2682cd6b # tse-master-virtualbox-2019.0.0-v0.1.1.vmdk
     centos: ami-262e9f5b # CentOS Linux 7 x86_64 HVM EBS ENA 1805_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-77ec9308.4
     discovery: ami-262e9f5b # CentOS Linux 7 x86_64 HVM EBS ENA 1805_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-77ec9308.4
-    windows: ami-041c2ed9f395ea43f # Windows_Server-2016-English-Full-Base-2018.11.28
+    windows: ami-04f6c3a108e0d348b # Windows_Server-2016-English-Full-Base-2019.02.13
     docker: ami-0d86fa8483cfc9a34 # Docker optimized Amazon Linux AMI 2.0.20190127 x86_64 ECS HVM GP2 - https://tinyurl.com/y9f6ao4t
   eu-central-1: # Frankfurt
     pm: ami-0aadcb439247edc90 # tse-master-virtualbox-2019.0.0-v0.1.1.vmdk


### PR DESCRIPTION
Old image no longer available on AWS