### PR TITLE
Recreate change for /etc/sudoers

### DIFF
--- a/manifests/create_bolt_workshop_targets.pp
+++ b/manifests/create_bolt_workshop_targets.pp
@@ -38,6 +38,7 @@ class awskit::create_bolt_workshop_targets (
   $user_data_linux = @(EOL)
     #! /bin/bash
     echo "<%= $master_ip %> <%= $awskit::master_name %> master" >> /etc/hosts
+    sed -i -r -e '/^\s*Defaults\s+secure_path/ s[=(.*)[=\1:/opt/puppetlabs/bin[' /etc/sudoers
     hostnamectl set-hostname <%= $certname_linux %>
     shutdown -r +1
     | EOL


### PR DESCRIPTION
This change got lost in a previous PR where the userdata was moved from Hiera to the manifest.