### PR TITLE
Disable Windows Defender for better speed

### DIFF
--- a/manifests/create_bolt_workshop_targets.pp
+++ b/manifests/create_bolt_workshop_targets.pp
@@ -58,6 +58,13 @@ class awskit::create_bolt_workshop_targets (
     Enable-NetFirewallRule -Name FPS-ICMP4-ERQ-In ;
     get-netfirewallrule -Name WINRM-HTTP-In-TCP-PUBLIC | Set-NetFirewallRule -RemoteAddress Any ;
     Rename-Computer -NewName <%= $auto_name %> -Force ;
+    $RegPath = "HKLM:SOFTWARE\Policies\Microsoft\Windows Defender"
+    If (!(Test-Path $RegPath)) {
+      New-Item -Path $RegPath
+    }
+    If (!((Get-ItemProperty -Path $RegPath -Name "DisableAntiSpyware" -ErrorAction SilentlyContinue).DisableAntiSpyware -eq 1)) {
+      New-ItemProperty -Path $RegPath -Name "DisableAntiSpyware" -PropertyType DWORD -Value 1 -Force
+    }
     iwr -Uri "http://downloads.puppet.com/windows/puppet/puppet-agent-x64-latest.msi" -OutFile ~/puppet-agent-x64-latest.msi ;
     cd ~ ;
     $MSIArguments = @(


### PR DESCRIPTION
This changes sets the HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\DisableAntiSpyware registry setting to 1, which disabled Windows Defender and provides a 2x speed boost to the Windows instance.