### PR TITLE
Now calculating and setting `termination_date` tag from awskit

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,7 +9,5 @@ remove_includes:
 includes:
   - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
   - env: CHECK=parallel_spec
-  - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
-    rvm: 2.3.3
   - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
     rvm: 2.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
     -
       env: CHECK=parallel_spec
     -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
-      rvm: 2.3.3
-    -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
 branches:

--- a/functions/calculate_termination_date.pp
+++ b/functions/calculate_termination_date.pp
@@ -12,10 +12,11 @@ function awskit::calculate_termination_date(
     $length = Integer($1)
     $unit = $2
     case $unit {
-      'w': { $duration = Timespan.new(days => 7*$length) }
+      'w': { $duration = Timespan.new(days => 7 * $length) }
       'd': { $duration = Timespan.new(days => $length) }
       'h': { $duration = Timespan.new(hours => $length) }
       'm': { $duration = Timespan.new(minutes => $length) }
+      default: { fail("Invalid lifetime: ${lifetime}") }
     }
     $termination_date = $start + $duration
     notice("Start timestamp: ${start}")

--- a/functions/calculate_termination_date.pp
+++ b/functions/calculate_termination_date.pp
@@ -1,0 +1,30 @@
+# Calculate a termination date from the current time and the $lifetime parameter
+# lifetime is of the format <integer><w|d|h|m>, for example "1d" or "3w"
+# The $start parameter is the starting timestamp as basis for the lifetime calculation
+# defaults to the current timestamp (only needed for unit testing)
+function awskit::calculate_termination_date(
+  String    $lifetime,
+  Timestamp $start = Timestamp.new(),
+  ) >> String {
+
+  # validate lifetime
+  if $lifetime =~ /^([0-9]+)(w|d|h|m)$/ {
+    $length = Integer($1)
+    $unit = $2
+    case $unit {
+      'w': { $duration = Timespan.new(days => 7*$length) }
+      'd': { $duration = Timespan.new(days => $length) }
+      'h': { $duration = Timespan.new(hours => $length) }
+      'm': { $duration = Timespan.new(minutes => $length) }
+    }
+    $termination_date = $start + $duration
+    notice("Start timestamp: ${start}")
+    notice("Lifetime: ${lifetime}")
+    notice("Termination date: ${termination_date}")
+  } else {
+    fail("Invalid lifetime: ${lifetime}")
+  }
+  # see https://puppet.com/docs/puppet/5.5/function.html#timestamp-specific-flags 
+  # for strftime flag documentation
+  strftime($termination_date, '%FT%T.%L000+00:00')
+}

--- a/manifests/create_host.pp
+++ b/manifests/create_host.pp
@@ -84,6 +84,11 @@ define awskit::create_host (
     $_user_data = undef
   }
 
+  $lifetime = $awskit::tags['lifetime']
+  $termination_date = awskit::calculate_termination_date($lifetime)
+  $_tags = { 'termination_date' => $termination_date} + $awskit::tags
+  notice("_tags: ${_tags}")
+
   ec2_instance { $name:
     ensure            => running,
     region            => $awskit::region,
@@ -98,7 +103,7 @@ define awskit::create_host (
     image_id          => $ami,
     security_groups   => $_security_groups,
     key_name          => $_key_name,
-    tags              => $awskit::tags,
+    tags              => $_tags,
     instance_type     => $_instance_type,
     user_data         => $_user_data,
     require           => Ec2_securitygroup[$_security_groups],


### PR DESCRIPTION
- Added new function `awskit::calculate_termination_date()` to calculate termination date
- Modified create_host.pp to explicitly calculate and set the `termination_date` tag based on specified lifetime