### PR TITLE
Automatic deletion of EBS volumes at termination

### DIFF
--- a/manifests/create_artifactory.pp
+++ b/manifests/create_artifactory.pp
@@ -32,16 +32,11 @@ class awskit::create_artifactory (
   }
 
   awskit::create_host { $instance_name:
-    ami                => $ami,
-    instance_type      => $instance_type,
-    user_data_template => 'awskit/artifactory_userdata.epp',
-    security_groups    => ["${facts['user']}-awskit-artifactory"],
-    block_devices      => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $ami,
+    instance_type         => $instance_type,
+    user_data_template    => 'awskit/artifactory_userdata.epp',
+    security_groups       => ["${facts['user']}-awskit-artifactory"],
+    delete_on_termination => true
   }
 
 }

--- a/manifests/create_artifactory.pp
+++ b/manifests/create_artifactory.pp
@@ -36,6 +36,12 @@ class awskit::create_artifactory (
     instance_type      => $instance_type,
     user_data_template => 'awskit/artifactory_userdata.epp',
     security_groups    => ["${facts['user']}-awskit-artifactory"],
+    block_devices      => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 
 }

--- a/manifests/create_bolt_workshop_master.pp
+++ b/manifests/create_bolt_workshop_master.pp
@@ -36,7 +36,13 @@ class awskit::create_bolt_workshop_master (
   awskit::create_host { $instance_name:
     ami             => $awskit::centos_ami,
     instance_type   => $instance_type,
-    security_groups => ["${facts['user']}-awskit-boltws"]
+    security_groups => ["${facts['user']}-awskit-boltws"],
+    block_devices   => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 
 }

--- a/manifests/create_bolt_workshop_master.pp
+++ b/manifests/create_bolt_workshop_master.pp
@@ -34,15 +34,10 @@ class awskit::create_bolt_workshop_master (
 
   #Create the PE Master
   awskit::create_host { $instance_name:
-    ami             => $awskit::centos_ami,
-    instance_type   => $instance_type,
-    security_groups => ["${facts['user']}-awskit-boltws"],
-    block_devices   => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $awskit::centos_ami,
+    instance_type         => $instance_type,
+    security_groups       => ["${facts['user']}-awskit-boltws"],
+    delete_on_termination => true
   }
 
 }

--- a/manifests/create_bolt_workshop_targets.pp
+++ b/manifests/create_bolt_workshop_targets.pp
@@ -86,6 +86,12 @@ class awskit::create_bolt_workshop_targets (
     user_data       => inline_epp($user_data_linux, { 'auto_name' => "${instance_name}-linux-teacher" }),
     security_groups => ["${facts['user']}-awskit-boltws"],
     key_name        => lookup('awskit::boltws_key_name'),
+    block_devices   => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 
   #Create the Windows target for teacher
@@ -105,6 +111,12 @@ class awskit::create_bolt_workshop_targets (
       user_data       => inline_epp($user_data_linux, { 'auto_name' => "${instance_name}-linux-student${i}" }),
       security_groups => ["${facts['user']}-awskit-boltws"],
       key_name        => lookup('awskit::boltws_key_name'),
+      block_devices   => [
+      {
+        'device_name'           => '/dev/sda1',
+        'volume_size'           => 8,
+        'delete_on_termination' => true
+      }],
     }
 
     #Create the Windows target

--- a/manifests/create_bolt_workshop_targets.pp
+++ b/manifests/create_bolt_workshop_targets.pp
@@ -81,17 +81,12 @@ class awskit::create_bolt_workshop_targets (
 
   #Create the Linux target for teacher
   awskit::create_host { "${instance_name}-linux-teacher":
-    ami             => $awskit::centos_ami,
-    instance_type   => $instance_type_linux,
-    user_data       => inline_epp($user_data_linux, { 'auto_name' => "${instance_name}-linux-teacher" }),
-    security_groups => ["${facts['user']}-awskit-boltws"],
-    key_name        => lookup('awskit::boltws_key_name'),
-    block_devices   => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $awskit::centos_ami,
+    instance_type         => $instance_type_linux,
+    user_data             => inline_epp($user_data_linux, { 'auto_name' => "${instance_name}-linux-teacher" }),
+    security_groups       => ["${facts['user']}-awskit-boltws"],
+    key_name              => lookup('awskit::boltws_key_name'),
+    delete_on_termination => true
   }
 
   #Create the Windows target for teacher
@@ -106,17 +101,12 @@ class awskit::create_bolt_workshop_targets (
   range(1,$count).each | $i | {
     #Create the Linux target
     awskit::create_host { "${instance_name}-linux-student${i}":
-      ami             => $awskit::centos_ami,
-      instance_type   => $instance_type_linux,
-      user_data       => inline_epp($user_data_linux, { 'auto_name' => "${instance_name}-linux-student${i}" }),
-      security_groups => ["${facts['user']}-awskit-boltws"],
-      key_name        => lookup('awskit::boltws_key_name'),
-      block_devices   => [
-      {
-        'device_name'           => '/dev/sda1',
-        'volume_size'           => 8,
-        'delete_on_termination' => true
-      }],
+      ami                   => $awskit::centos_ami,
+      instance_type         => $instance_type_linux,
+      user_data             => inline_epp($user_data_linux, { 'auto_name' => "${instance_name}-linux-student${i}" }),
+      security_groups       => ["${facts['user']}-awskit-boltws"],
+      key_name              => lookup('awskit::boltws_key_name'),
+      delete_on_termination => true
     }
 
     #Create the Windows target

--- a/manifests/create_cd4pe.pp
+++ b/manifests/create_cd4pe.pp
@@ -48,6 +48,12 @@ class awskit::create_cd4pe (
     instance_type      => $instance_type,
     user_data_template => 'awskit/linux_userdata.epp',
     security_groups    => ["${facts['user']}-awskit-cd4pe"],
+    block_devices      => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 
 }

--- a/manifests/create_cd4pe.pp
+++ b/manifests/create_cd4pe.pp
@@ -43,17 +43,12 @@ class awskit::create_cd4pe (
   }
 
   awskit::create_host { $instance_name:
-    ami                => $ami,
-    role               => 'cd4pe_server',
-    instance_type      => $instance_type,
-    user_data_template => 'awskit/linux_userdata.epp',
-    security_groups    => ["${facts['user']}-awskit-cd4pe"],
-    block_devices      => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $ami,
+    role                  => 'cd4pe_server',
+    instance_type         => $instance_type,
+    user_data_template    => 'awskit/linux_userdata.epp',
+    security_groups       => ["${facts['user']}-awskit-cd4pe"],
+    delete_on_termination => true
   }
 
 }

--- a/manifests/create_discovery.pp
+++ b/manifests/create_discovery.pp
@@ -34,5 +34,11 @@ class awskit::create_discovery (
     instance_type      => $instance_type,
     user_data_template => 'awskit/discovery_userdata.epp',
     security_groups    => ["${facts['user']}-awskit-disco"],
+    block_devices      => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 }

--- a/manifests/create_discovery.pp
+++ b/manifests/create_discovery.pp
@@ -30,15 +30,10 @@ class awskit::create_discovery (
   }
 
   awskit::create_host { $instance_name:
-    ami                => $ami,
-    instance_type      => $instance_type,
-    user_data_template => 'awskit/discovery_userdata.epp',
-    security_groups    => ["${facts['user']}-awskit-disco"],
-    block_devices      => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $ami,
+    instance_type         => $instance_type,
+    user_data_template    => 'awskit/discovery_userdata.epp',
+    security_groups       => ["${facts['user']}-awskit-disco"],
+    delete_on_termination => true
   }
 }

--- a/manifests/create_discovery_nodes.pp
+++ b/manifests/create_discovery_nodes.pp
@@ -33,6 +33,12 @@ class awskit::create_discovery_nodes (
       instance_type      => $instance_type,
       user_data_template => 'awskit/discovery_node_userdata.epp',
       security_groups    => ["${facts['user']}-awskit-disco"],
+      block_devices      => [
+      {
+        'device_name'           => '/dev/sda1',
+        'volume_size'           => 8,
+        'delete_on_termination' => true
+      }],
     }
   }
 }

--- a/manifests/create_discovery_nodes.pp
+++ b/manifests/create_discovery_nodes.pp
@@ -29,16 +29,11 @@ class awskit::create_discovery_nodes (
 
   range(1,$count).each | $i | {
     awskit::create_host { "${instance_name}-${i}":
-      ami                => $awskit::centos_ami,
-      instance_type      => $instance_type,
-      user_data_template => 'awskit/discovery_node_userdata.epp',
-      security_groups    => ["${facts['user']}-awskit-disco"],
-      block_devices      => [
-      {
-        'device_name'           => '/dev/sda1',
-        'volume_size'           => 8,
-        'delete_on_termination' => true
-      }],
+      ami                   => $awskit::centos_ami,
+      instance_type         => $instance_type,
+      user_data_template    => 'awskit/discovery_node_userdata.epp',
+      security_groups       => ["${facts['user']}-awskit-disco"],
+      delete_on_termination => true
     }
   }
 }

--- a/manifests/create_dockerhost.pp
+++ b/manifests/create_dockerhost.pp
@@ -37,5 +37,11 @@ class awskit::create_dockerhost (
     instance_type      => $instance_type,
     user_data_template => 'awskit/dockerhost_userdata.epp',
     security_groups    => ["${facts['user']}-awskit-dockerhost"],
+    block_devices      => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 }

--- a/manifests/create_dockerhost.pp
+++ b/manifests/create_dockerhost.pp
@@ -33,15 +33,10 @@ class awskit::create_dockerhost (
   }
 
   awskit::create_host { $instance_name:
-    ami                => $ami,
-    instance_type      => $instance_type,
-    user_data_template => 'awskit/dockerhost_userdata.epp',
-    security_groups    => ["${facts['user']}-awskit-dockerhost"],
-    block_devices      => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $ami,
+    instance_type         => $instance_type,
+    user_data_template    => 'awskit/dockerhost_userdata.epp',
+    security_groups       => ["${facts['user']}-awskit-dockerhost"],
+    delete_on_termination => true
   }
 }

--- a/manifests/create_gitlab.pp
+++ b/manifests/create_gitlab.pp
@@ -48,6 +48,12 @@ class awskit::create_gitlab (
     instance_type      => $instance_type,
     user_data_template => 'awskit/linux_userdata.epp',
     security_groups    => ["${facts['user']}-awskit-gitlab"],
+    block_devices      => [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
   }
 
 }

--- a/manifests/create_gitlab.pp
+++ b/manifests/create_gitlab.pp
@@ -43,17 +43,12 @@ class awskit::create_gitlab (
   }
 
   awskit::create_host { $instance_name:
-    ami                => $ami,
-    role               => 'git_server',
-    instance_type      => $instance_type,
-    user_data_template => 'awskit/linux_userdata.epp',
-    security_groups    => ["${facts['user']}-awskit-gitlab"],
-    block_devices      => [
-    {
-      'device_name'           => '/dev/sda1',
-      'volume_size'           => 8,
-      'delete_on_termination' => true
-    }],
+    ami                   => $ami,
+    role                  => 'git_server',
+    instance_type         => $instance_type,
+    user_data_template    => 'awskit/linux_userdata.epp',
+    security_groups       => ["${facts['user']}-awskit-gitlab"],
+    delete_on_termination => true
   }
 
 }

--- a/manifests/create_host.pp
+++ b/manifests/create_host.pp
@@ -26,6 +26,7 @@ define awskit::create_host (
   $run_agent          = true,
   $security_groups    = 'none',
   $key_name           = 'none',
+  $block_devices      = 'none',
   $role               = undef,
   $environment        = undef,
   $public_ip          = undef,
@@ -51,6 +52,11 @@ define awskit::create_host (
   $_key_name = $key_name ? {
     'none'  => $awskit::key_name,
     default => $key_name,
+  }
+
+  $_block_devices = $block_devices ? {
+    'none'  => undef,
+    default => $block_devices,
   }
 
   $host_config = lookup("awskit::host_config.${name}", Hash, 'first', {})
@@ -101,6 +107,7 @@ define awskit::create_host (
     #  see also https://github.com/puppetlabs/puppetlabs-aws/issues/191
     subnet            => $awskit::subnet,
     image_id          => $ami,
+    block_devices     => $_block_devices,
     security_groups   => $_security_groups,
     key_name          => $_key_name,
     tags              => $_tags,

--- a/manifests/create_host.pp
+++ b/manifests/create_host.pp
@@ -19,17 +19,17 @@
 define awskit::create_host (
   $ami,
   $instance_type,
-  $user_data          = undef,
-  $user_data_template = undef,
-  $master_ip          = undef,
-  $master_name        = undef,
-  $run_agent          = true,
-  $security_groups    = 'none',
-  $key_name           = 'none',
-  $block_devices      = 'none',
-  $role               = undef,
-  $environment        = undef,
-  $public_ip          = undef,
+  $user_data             = undef,
+  $user_data_template    = undef,
+  $master_ip             = undef,
+  $master_name           = undef,
+  $run_agent             = true,
+  $security_groups       = 'none',
+  $key_name              = 'none',
+  $delete_on_termination = false,
+  $role                  = undef,
+  $environment           = undef,
+  $public_ip             = undef,
 ){
 
   include awskit
@@ -54,9 +54,15 @@ define awskit::create_host (
     default => $key_name,
   }
 
-  $_block_devices = $block_devices ? {
-    'none'  => undef,
-    default => $block_devices,
+  if $delete_on_termination {
+    $block_devices = [
+    {
+      'device_name'           => '/dev/sda1',
+      'volume_size'           => 8,
+      'delete_on_termination' => true
+    }],
+  } else {
+    $block_devices = undef
   }
 
   $host_config = lookup("awskit::host_config.${name}", Hash, 'first', {})
@@ -107,7 +113,7 @@ define awskit::create_host (
     #  see also https://github.com/puppetlabs/puppetlabs-aws/issues/191
     subnet            => $awskit::subnet,
     image_id          => $ami,
-    block_devices     => $_block_devices,
+    block_devices     => $block_devices,
     security_groups   => $_security_groups,
     key_name          => $_key_name,
     tags              => $_tags,

--- a/manifests/create_host.pp
+++ b/manifests/create_host.pp
@@ -60,7 +60,7 @@ define awskit::create_host (
       'device_name'           => '/dev/sda1',
       'volume_size'           => 8,
       'delete_on_termination' => true
-    }],
+    }]
   } else {
     $block_devices = undef
   }

--- a/manifests/create_linux_node.pp
+++ b/manifests/create_linux_node.pp
@@ -25,6 +25,12 @@ class awskit::create_linux_node (
       user_data_template => 'awskit/linux_userdata.epp',
       role               => $role,
       environment        => $environment,
+      block_devices      => [
+      {
+        'device_name'           => '/dev/sda1',
+        'volume_size'           => 8,
+        'delete_on_termination' => true
+      }],
     }
   }
 }

--- a/manifests/create_linux_node.pp
+++ b/manifests/create_linux_node.pp
@@ -20,17 +20,12 @@ class awskit::create_linux_node (
 
   range(1,$count).each | $i | {
     awskit::create_host { "${instance_name}-${i}":
-      ami                => $awskit::centos_ami,
-      instance_type      => $instance_type,
-      user_data_template => 'awskit/linux_userdata.epp',
-      role               => $role,
-      environment        => $environment,
-      block_devices      => [
-      {
-        'device_name'           => '/dev/sda1',
-        'volume_size'           => 8,
-        'delete_on_termination' => true
-      }],
+      ami                   => $awskit::centos_ami,
+      instance_type         => $instance_type,
+      user_data_template    => 'awskit/linux_userdata.epp',
+      role                  => $role,
+      environment           => $environment,
+      delete_on_termination => true
     }
   }
 }


### PR DESCRIPTION
Configures the 'block_devices' attribute where necessary (i.e. Linux instances) to switch the 'delete_on_termination' tag to true during instance creation. Has no effect on existing instances, will only affect newly created instances.