### PR TITLE
Make the two public_key parameters optional

### DIFF
--- a/tasks/conf_control_repo.json
+++ b/tasks/conf_control_repo.json
@@ -9,11 +9,11 @@
     },
     "public_key_name": {
       "description": "Name of the public key to configure for GOGS",
-      "type": "String"
+      "type": "Optional[String[1]]"
     },
     "public_key_value": {
       "description": "Name of the public key to configure for GOGS",
-      "type": "String"
+      "type": "Optional[String[1]]"
     }
   }
 }


### PR DESCRIPTION
Leverages the "Optional[String[1]]" type in tasks/conf_control_repo.json so you can optionally skip adding a custom ssh keypair to the git server. Use case: You want to change the control-repo content, e.g. to a customized fork or whatever of the standard control repo, but you're not going to clone/modify it during your demo.